### PR TITLE
Feature/liquidation exponent

### DIFF
--- a/src/hooks/fetchAllMarkets.ts
+++ b/src/hooks/fetchAllMarkets.ts
@@ -191,13 +191,18 @@ export const fetchPositionsAndBids = async (
           nftMints.map(async (nft) => {
             if (nft.toString() != '11111111111111111111111111111111') {
               let debt = 0;
-              // why did we had a - infront of our reserves? the exponent was already -6 || -9
-              const exponent = honeyReserves[0].data.exponent;
+              const exponent = -honeyReserves[0].data.exponent;
               if (item.account?.loans.length != 0) {
                 const bnDebt = onChainNumberToBN(marketReserves.reserves[0].loanNoteExchangeRate)
                   .mul(item.account?.loans[0].amount)
-                  .div(new BN(10 ** 6));
-                debt = bnDebt.toNumber() / 10 ** exponent;
+                  .div(new BN(10 ** 6))
+                if (exponent == -6 || exponent == 6) {
+                  // added an additional 10**3
+                  const val = bnDebt.div(new BN(Math.pow(10, 3)));
+                  debt = val.toNumber() / 10 ** exponent
+                } else {
+                    debt = bnDebt.toNumber() / 10 ** exponent;  
+                }
               }
 
               let position: NftPosition = {
@@ -210,6 +215,7 @@ export const fetchPositionsAndBids = async (
                 highest_bid: highestBid,
                 verifiedCreator: honeyMarket.nftCollectionCreator,
               };
+
               arrPositions.push(position);
             }
           }),

--- a/src/hooks/fetchAllMarkets.ts
+++ b/src/hooks/fetchAllMarkets.ts
@@ -156,7 +156,9 @@ export const fetchPositionsAndBids = async (
     connection,
     honeyMarket.nftSwitchboardPriceAggregator,
   );
-  const nftPrice = nftPriceUsd / solPriceUsd;
+
+  // set nft price to be usd if market is usdc | if not set to be usd/solpriceusd
+  const nftPrice = honeyReserves[0].data.exponent === -6 ?  nftPriceUsd : nftPriceUsd / solPriceUsd;
 
   // reserve info
   const marketReserves = await program.account.market.fetch(honeyMarket.address);
@@ -189,7 +191,8 @@ export const fetchPositionsAndBids = async (
           nftMints.map(async (nft) => {
             if (nft.toString() != '11111111111111111111111111111111') {
               let debt = 0;
-              const exponent = -honeyReserves[0].data.exponent;
+              // why did we had a - infront of our reserves? the exponent was already -6 || -9
+              const exponent = honeyReserves[0].data.exponent;
               if (item.account?.loans.length != 0) {
                 const bnDebt = onChainNumberToBN(marketReserves.reserves[0].loanNoteExchangeRate)
                   .mul(item.account?.loans[0].amount)


### PR DESCRIPTION
Please validate the logic implemented / test it out locally. 
For me the SOL markets now work properly and the USDC also work properly. 

Im logging the position on line 218 of the hooks/fetchAllMarkets.ts hook 
Which now displays the debt correct 

Also changed the 
nftPrice;
```ts
// set nft price to be usd if market is usdc | if not set to be usd/solpriceusd
const nftPrice = honeyReserves[0].data.exponent === -6 ?  nftPriceUsd : nftPriceUsd / solPriceUsd;
```